### PR TITLE
Alias supabase commands for brevity

### DIFF
--- a/sb.sh
+++ b/sb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# All your supabase commands using npx
+alias sb='npx supabase'
+
+echo "Use 'sb' instead of 'supabase'"
+echo "Example: sb status"
+


### PR DESCRIPTION
Add `sb.sh` script to provide a convenient `sb` alias for `npx supabase` commands.

---
<a href="https://cursor.com/background-agent?bcId=bc-960d8b26-2459-4d28-92a9-7bf164101767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-960d8b26-2459-4d28-92a9-7bf164101767">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

